### PR TITLE
fix: fix undefined typo, use total_frame_count instead

### DIFF
--- a/cosmos_transfer2/_src/imaginaire/auxiliary/guardrail/video_content_safety_filter/video_content_safety_filter.py
+++ b/cosmos_transfer2/_src/imaginaire/auxiliary/guardrail/video_content_safety_filter/video_content_safety_filter.py
@@ -142,7 +142,7 @@ class VideoContentSafetyFilter(ContentSafetyGuardrail):
         if (unsafe_frame_count / total_frame_count) > (CUTOFF_UNSAFE_FRAMES_PERCENT / 100):
             is_safe = False
             log.warning(
-                f"Unsafe frame count {unsafe_frame_count} is greater than {CUTOFF_UNSAFE_FRAMES_PERCENT}% of total frames {len(frame_numbers)}"
+                f"Unsafe frame count {unsafe_frame_count} is greater than {CUTOFF_UNSAFE_FRAMES_PERCENT}% of total frames {total_frame_count}"
             )
 
         video_data = {


### PR DESCRIPTION
Originally, `len(frame_numbers)` is used in [video_content_safety_filter.py](https://github.com/nvidia-cosmos/cosmos-transfer2.5/blob/84da06be20068de51a99900a720d20d371008d05/cosmos_transfer2/_src/imaginaire/auxiliary/guardrail/video_content_safety_filter/video_content_safety_filter.py), but it is undefined. `total_frame_count` can be used here.