### PR TITLE
This PR fixes the issue reported in nvidia-cosmos/cosmos-transfer2.5 #17.

### DIFF
--- a/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
+++ b/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
@@ -220,6 +220,9 @@ class ControlVideo2WorldInference:
         Pad input frames if total frames is less than chunk size
         """
         if num_total_frames < num_video_frames_per_chunk:
+            # Check whether the input_frames is empty. If so, there is nothing to pad.
+            if num_total_frames == 0:
+                raise ValueError("No input frames; cannot pad. Verify that video frame counts match.")
             if padding_mode == "repeat":
                 last_frame = input_frames[:, -1:, :, :]  # Get the last frame
                 padding = last_frame.repeat(1, num_video_frames_per_chunk - num_total_frames, 1, 1)


### PR DESCRIPTION
This PR fixes the issue reported in nvidia-cosmos/cosmos-transfer2.5 #17
**Root Cause**
The problem occurs when the input video contains 221 frames while the control video contains only 144 frames. As a result, the final chunk of the control video is empty (0 frames).
When the padding mode is set to the default "reflect", the following code runs:
```
padding_frames = input_frames.flip(dims=[1])[:, :padding, :, :]
input_frames = torch.cat([input_frames, padding_frames], dim=1)
```
Because input_frames is empty, the padding operation never terminates, causing the process to hang.

**Fix**
An empty-frame check has been added before padding to detect this case early and raise a clear warning to users, advising them to verify that the input and control videos have matching frame counts.