### PR TITLE
Fix: Prevent infinite loop in video_to_frames() by breaking on read failure

### DIFF
--- a/cosmos_transfer2/_src/transfer2/auxiliary/sam2/sam2_utils.py
+++ b/cosmos_transfer2/_src/transfer2/auxiliary/sam2/sam2_utils.py
@@ -75,20 +75,20 @@ def video_to_frames(input_loc, output_loc):
         # Extract the frame
         ret, frame = cap.read()
         if not ret:
-            continue
+            break
         # Write the results back to output location.
         cv2.imwrite(output_loc + "/%#05d.jpg" % (count + 1), frame)
         count = count + 1
         # If there are no more frames left
         if count > (video_length - 1):
-            # Log the time again
-            time_end = time.time()
-            # Release the feed
-            cap.release()
-            # Print stats
-            print("Done extracting frames.\n%d frames extracted" % count)
-            print("It took %d seconds forconversion." % (time_end - time_start))
             break
+    # Log the time again
+    time_end = time.time()
+    # Release the feed
+    cap.release()
+    # Print stats
+    print("Done extracting frames.\n%d frames extracted" % count)
+    print("It took %d seconds for conversion." % (time_end - time_start))
 
 
 # Function to generate video


### PR DESCRIPTION
## Description

Fixed a potential infinite loop bug in the `video_to_frames()` function in `cosmos_transfer2/_src/transfer2/auxiliary/sam2/sam2_utils.py` where the function would continue looping indefinitely when video frames could no longer be read.

## Problem

In the original implementation, when `cv2.VideoCapture.read()` failed (e.g., end of video or read error), the code used `continue` which would:

- Skip the current iteration but continue the loop
- Since `cap.isOpened()` was still `True`, the loop would repeat indefinitely
- This caused unnecessary CPU usage and prevented proper cleanup

## Solution

Changed `continue` to `break` and refactored the cleanup logic to avoid code duplication.
