### PR TITLE
Fix resource leaks, mutable default arguments, and duplicate line

### DIFF
--- a/cosmos_transfer2/_src/predict2/checkpointer/dcp.py
+++ b/cosmos_transfer2/_src/predict2/checkpointer/dcp.py
@@ -244,7 +244,9 @@ class ModelWrapper(Stateful):
                 f"ModelWrapper only supports DiffusionModel when load_ema_to_reg is True, but got {type(model)}"
             )
 
-    def state_dict(self, mapping_keys: dict[str, str] = {}) -> Dict[str, Any]:
+    def state_dict(self, mapping_keys: dict[str, str] | None = None) -> Dict[str, Any]:
+        if mapping_keys is None:
+            mapping_keys = {}
         _state_dict = {k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()}
         if self.load_ema_to_reg:
             assert not self.model[0].config.ema.enabled, (

--- a/cosmos_transfer2/_src/predict2/text_encoders/reason1.py
+++ b/cosmos_transfer2/_src/predict2/text_encoders/reason1.py
@@ -231,10 +231,12 @@ class QwenVLBaseModel(QwenModel):
     MODIFICATIONS: adding the hidden states to the output.
     """
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)

--- a/cosmos_transfer2/_src/reason1/models/vlm_base.py
+++ b/cosmos_transfer2/_src/reason1/models/vlm_base.py
@@ -414,7 +414,7 @@ class VLMBaseModel(torch.nn.Module):
     def build_model(self, model_config):
         raise NotImplementedError
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The forward pass of the model.
         Returns:

--- a/cosmos_transfer2/_src/reason1/models/vlm_qwen.py
+++ b/cosmos_transfer2/_src/reason1/models/vlm_qwen.py
@@ -370,10 +370,12 @@ class QwenModel(VLMBaseModel):
             logits = DTensor.from_local(logits, device_mesh=self.cp_mesh, placements=[Shard(1)]).full_tensor()
         return logits
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)

--- a/cosmos_transfer2/_src/reason1/models/vlm_qwen_omni.py
+++ b/cosmos_transfer2/_src/reason1/models/vlm_qwen_omni.py
@@ -268,17 +268,17 @@ class QwenVLBaseModel(QwenModel):
     MODIFICATIONS: adding the hidden states to the output.
     """
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)
         pixel_values_videos = data_batch.get("videos", None)
         video_grid_thw = data_batch.get("video_grid_thw", None)
-        attention_mask = data_batch.get("padding_mask", None)
-
         attention_mask = data_batch.get("padding_mask", None)
 
         if image_grid_thw is not None:

--- a/cosmos_transfer2/inference.py
+++ b/cosmos_transfer2/inference.py
@@ -198,7 +198,8 @@ class Control2WorldInference:
 
         if self.device_rank == 0:
             output_dir.mkdir(parents=True, exist_ok=True)
-            open(f"{output_path}.json", "w").write(sample.model_dump_json())
+            with open(f"{output_path}.json", "w") as f:
+                f.write(sample.model_dump_json())
             log.info(f"Saved arguments to {output_path}.json")
 
             with self.benchmark_timer("text_guardrail"):

--- a/cosmos_transfer2/multiview.py
+++ b/cosmos_transfer2/multiview.py
@@ -155,7 +155,8 @@ class MultiviewInference:
 
         if self.rank0:
             output_dir.mkdir(parents=True, exist_ok=True)
-            open(f"{output_path}.json", "w").write(sample.model_dump_json())
+            with open(f"{output_path}.json", "w") as f:
+                f.write(sample.model_dump_json())
             log.info(f"Saved arguments to {output_path}.json")
 
         # setup the control and input videos dict

--- a/packages/cosmos-gradio/cosmos_gradio/model_ipc/command_ipc.py
+++ b/packages/cosmos-gradio/cosmos_gradio/model_ipc/command_ipc.py
@@ -81,11 +81,11 @@ class WorkerCommand:
 
 
 class WorkerException(Exception):
-    def __init__(self, rank, status, result_json: dict[str, Any] = {}):
+    def __init__(self, rank, status, result_json: dict[str, Any] | None = None):
         super().__init__("worker exception")
         self.rank = rank
         self.status = status
-        self.results = result_json
+        self.results = result_json if result_json is not None else {}
 
     def __str__(self):
         rank = self.rank
@@ -135,7 +135,7 @@ class WorkerStatus:
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    def signal_status(self, rank: int, status: str, request_id: int, result: dict[str, Any] = {}) -> None:
+    def signal_status(self, rank: int, status: str, request_id: int, result: dict[str, Any] | None = None) -> None:
         """signal individual worker status per rank
 
         Args:
@@ -143,6 +143,8 @@ class WorkerStatus:
             status (str): The status of the worker is either "success" or an error string
             results_json (dict[str, Any]): The result json of the worker/model. Model can place arbitrary data here.
         """
+        if result is None:
+            result = {}
         status_file = f"/tmp/worker_{rank}_status.json"
 
         status_data = StatusData(rank=rank, status=status, request_id=request_id, result=result)


### PR DESCRIPTION
## Description

Fixed resource leaks from unclosed file handles, mutable default arguments that can cause shared state mutations, and a duplicate line.

## Problem

1. **Resource leaks**: `open(...).write(...)` creates a file handle that is never explicitly closed, relying on garbage collection instead of deterministic cleanup.

2. **Mutable default arguments**: Several functions use mutable dicts (`{}`) as default parameter values. In Python, mutable defaults are shared across all calls to the function. This is particularly problematic in `dcp.py` where `mapping_keys` is modified in-place via `.update()` — subsequent calls without an explicit argument would see the mutations from previous calls.

3. **Duplicate line**: `attention_mask = data_batch.get("padding_mask", None)` appears twice consecutively in `vlm_qwen_omni.py`.

## Solution

- Wrapped `open()` calls with context managers (`with` statements) in `inference.py` and `multiview.py`.
- Replaced mutable dict defaults with `None` + guard pattern across VLM models, checkpointer, and command IPC.
- Removed the duplicate line in `vlm_qwen_omni.py`.