### PR TITLE
Add repository fallback for experimental checkpoint downloads

### DIFF
--- a/cosmos_transfer2/_src/imaginaire/utils/checkpoint_db.py
+++ b/cosmos_transfer2/_src/imaginaire/utils/checkpoint_db.py
@@ -201,10 +201,11 @@ class CheckpointFileHf(_CheckpointHf):
         if self.repository in ["nvidia/Cosmos-Experimental", "nvidia-cosmos-ea/Cosmos-Experimental"]:
             repositories = [
                 self.repository,
-                "nvidia-cosmos-ea/Cosmos-Experimental" if self.repository == "nvidia/Cosmos-Experimental"
+                "nvidia-cosmos-ea/Cosmos-Experimental"
+                if self.repository == "nvidia/Cosmos-Experimental"
                 else "nvidia/Cosmos-Experimental",
             ]
-        
+
         for repository in repositories:
             try:
                 cmd_args = [
@@ -220,10 +221,8 @@ class CheckpointFileHf(_CheckpointHf):
                 return path
             except subprocess.CalledProcessError:
                 continue
-        
-        raise RuntimeError(
-            f"Failed to download {self.filename} from any experimental repository."
-        )
+
+        raise RuntimeError(f"Failed to download {self.filename} from any experimental repository.")
 
 
 class CheckpointDirHf(_CheckpointHf):

--- a/cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py
+++ b/cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py
@@ -142,27 +142,27 @@ def test_get_checkpoint_dir():
 def test_experimental_repository_fallback():
     """Test fallback between experimental repositories."""
     import subprocess
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch
 
     experimental_repo = "nvidia/Cosmos-Experimental"
     fallback_repo = "nvidia-cosmos-ea/Cosmos-Experimental"
-    
+
     if INTERNAL:
         return
-    
+
     config = CheckpointFileHf(
         repository=experimental_repo,
         revision="main",
         filename="test_file.pt",
     )
-    
+
     call_count = [0]
-    
+
     def mock_hf_download(cmd_args):
         """Mock _hf_download to simulate first failure, second success."""
         call_count[0] += 1
         repo = cmd_args[0]
-        
+
         if call_count[0] == 1:
             # First call (experimental repo) - fail
             assert repo == experimental_repo
@@ -173,40 +173,41 @@ def test_experimental_repository_fallback():
             return "/path/to/test_file.pt"
         else:
             raise AssertionError(f"Unexpected call count: {call_count[0]}")
-    
+
     # Mock os.path.exists to avoid file system checks in test
     with patch("cosmos_transfer2._src.imaginaire.utils.checkpoint_db._hf_download", side_effect=mock_hf_download):
         with patch("os.path.exists", return_value=True):
             path = config._download()
             assert path == "/path/to/test_file.pt"
             assert call_count[0] == 2
+
+
 @pytest.mark.L0
 def test_non_experimental_repository_no_fallback():
     """Test that non-experimental repositories don't use fallback."""
-    import subprocess
     from unittest.mock import patch
 
     normal_repo = "nvidia/Cosmos-Predict2.5-2B"
-    
+
     if INTERNAL:
         return
-    
+
     config = CheckpointFileHf(
         repository=normal_repo,
         revision="main",
         filename="test_file.pt",
     )
-    
+
     call_count = [0]
-    
+
     def mock_hf_download(cmd_args):
         """Mock _hf_download to simulate success on first call."""
         call_count[0] += 1
         repo = cmd_args[0]
-        
+
         assert repo == normal_repo
         return "/path/to/test_file.pt"
-    
+
     with patch("cosmos_transfer2._src.imaginaire.utils.checkpoint_db._hf_download", side_effect=mock_hf_download):
         with patch("os.path.exists", return_value=True):
             path = config._download()
@@ -222,17 +223,17 @@ def test_both_repositories_fail():
 
     if INTERNAL:
         return
-    
+
     config = CheckpointFileHf(
         repository="nvidia/Cosmos-Experimental",
         revision="main",
         filename="test_file.pt",
     )
-    
+
     def mock_hf_download_fail(cmd_args):
         """Mock _hf_download to always fail."""
         raise subprocess.CalledProcessError(1, cmd_args)
-    
+
     with patch("cosmos_transfer2._src.imaginaire.utils.checkpoint_db._hf_download", side_effect=mock_hf_download_fail):
         with pytest.raises(RuntimeError, match="Failed to download test_file.pt from any experimental repository"):
             config._download()


### PR DESCRIPTION
Fixes: https://github.com/nvidia-cosmos/cosmos-transfer2.5/issues/197

### Problem
Users may lack permission to `nvidia/Cosmos-Experimental` but have access to `nvidia-cosmos-ea/Cosmos-Experimental`. Current implementation fails immediately without trying the alternative repository.

### Summary
Add automatic repository fallback for experimental checkpoints. When `nvidia/Cosmos-Experimental` download fails, automatically retry with `nvidia-cosmos-ea/Cosmos-Experimental`.

### Changes

`cosmos_transfer2/_src/imaginaire/utils/checkpoint_db.py`

- Added repository list logic in `CheckpointFileHf._download()`
- Implemented try-except loop to retry with fallback repository on failure
- Added informative `RuntimeError` when all repositories fail

`cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py`

- `test_experimental_repository_fallback`: Verifies successful fallback from primary to alternative repository
- `test_non_experimental_repository_no_fallback`: Ensures non-experimental repositories don't use fallback behavior
- `test_both_repositories_fail`: Confirms `RuntimeError` is raised when all repositories fail


Test Results: All 3 tests pass successfully:

```bash
cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py::test_experimental_repository_fallback PASSED [ 33%]
cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py::test_non_experimental_repository_no_fallback PASSED [ 66%]
cosmos_transfer2/_src/imaginaire/utils/checkpoint_db_test.py::test_both_repositories_fail PASSED [100%]

3 passed, 7 warnings in 0.83s
```