### PR TITLE
Add missing VelocityPassthroughWrapper and enable distilled edge model

### DIFF
--- a/cosmos_transfer2/_src/predict2/modules/denoiser_scaling.py
+++ b/cosmos_transfer2/_src/predict2/modules/denoiser_scaling.py
@@ -76,3 +76,20 @@ class RectifiedFlow_sCMWrapper:
             self.sigma_data * torch.sin(trigflow_t) / (torch.cos(trigflow_t) + self.sigma_data * torch.sin(trigflow_t))
         )
         return c_skip.to(dtype), c_out.to(dtype), c_in.to(dtype), c_noise.to(dtype)
+
+
+class VelocityPassthroughWrapper:
+    """
+    Passthrough scaling: returns raw velocity prediction without EDM preconditioning.
+    c_skip=0, c_out=1, c_in=1, c_noise=time.
+    """
+
+    def __init__(self, sigma_data: float = 1.0):
+        self.sigma_data = sigma_data
+
+    def __call__(self, trigflow_t: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        c_skip = torch.zeros_like(trigflow_t)
+        c_out = torch.ones_like(trigflow_t)
+        c_in = torch.ones_like(trigflow_t)
+        c_noise = trigflow_t
+        return c_skip, c_out, c_in, c_noise

--- a/cosmos_transfer2/config.py
+++ b/cosmos_transfer2/config.py
@@ -161,12 +161,12 @@ MODEL_CHECKPOINTS = {
     ModelKey(variant=ModelVariant.SEG): CheckpointConfig.from_uri("5136ef49-6d8d-42e8-8abf-7dac722a304a"),
     ModelKey(variant=ModelVariant.VIS): CheckpointConfig.from_uri("ba2f44f2-c726-4fe7-949f-597069d9b91c"),
     ModelKey(variant=ModelVariant.AUTO_MULTIVIEW): CheckpointConfig.from_uri("4ecc66e9-df19-4aed-9802-0d11e057287a"),
+    ModelKey(variant=ModelVariant.EDGE, distilled=True): CheckpointConfig.from_uri(
+        "41f07f13-f2e4-4e34-ba4c-86f595acbc20"
+    ),
 }
 if EXPERIMENTAL_CHECKPOINTS:
     MODEL_CHECKPOINTS |= {
-        ModelKey(variant=ModelVariant.EDGE, distilled=True): CheckpointConfig.from_uri(
-            "41f07f13-f2e4-4e34-ba4c-86f595acbc20"
-        ),
         # Transfer2.5 Agibot Control-Conditioned Multiview
         ModelKey(variant=ModelVariant.ROBOT_MULTIVIEW_AGIBOT_DEPTH): CheckpointConfig.from_uri(
             "32514ba1-6d05-4ce5-997d-a3b5bf894cab"


### PR DESCRIPTION
## Summary
- Add missing `VelocityPassthroughWrapper` class to `denoiser_scaling.py` (fixes #216)
- Move distilled edge checkpoint out of `EXPERIMENTAL_CHECKPOINTS` gate (fixes #218)

## Test plan
- Ran distilled edge inference end-to-end on H100 — video generated successfully

**Environment**
- Hardware: AWS EC2 H100
- CUDA Version: 12.8
- Revision: `eb1999f`

**Command**
```bash
python3 examples/inference.py \
    -i assets/robot_example/distilled/edge/robot_edge_spec.json \
    -o outputs/distilled/edge \
    --model=edge/distilled
```

<details>
<summary>Full inference log</summary>

```
[04-10 01:50:42|INFO|packages/cosmos-oss/cosmos_oss/init.py:96:_init_log_files] Log saved to outputs/distilled/edge/console.log
[04-10 01:51:04|INFO] Downloading checkpoint nvidia/Cosmos-Predict2.5-2B/robot/action-cond
[04-10 01:51:05|INFO] Downloading checkpoint Qwen/Qwen2.5-VL-7B-Instruct
[04-10 01:51:07|INFO] Downloading checkpoint nvidia/Cosmos-Reason1.1-7B
[04-10 01:51:27|INFO] Downloading checkpoint Wan2.1/vae
[04-10 01:51:32|INFO] Downloading checkpoint nvidia/Cosmos-Transfer2.5-2B/distilled/edge
[04-10 01:51:36|INFO] Setting net_fake_score to None for distilled model inference
[04-10 01:51:36|INFO] Found 1 hint keys across all samples
[04-10 01:51:36|INFO] Generating 1 samples: ['robot_edge']
[04-10 01:51:36|INFO] [1/1] Processing sample robot_edge
[04-10 01:51:39|SUCCESS] Passed guardrail on prompt
[04-10 01:52:18|WARNING] Generated output has 121 frames (> 93). The distilled Transfer 2.5 model is not trained to support auto-regressive generation
[04-10 01:52:19|INFO] edge control video saved to outputs/distilled/edge/robot_edge_control_edge.mp4
[04-10 01:52:23|SUCCESS] Passed guardrail on generated video
[04-10 01:52:23|SUCCESS] Generated video saved to outputs/distilled/edge/robot_edge.mp4
```

</details>