### PR TITLE
Fix broken HuggingFace revision for Wan2.1/vae tokenizer checkpoint

### DIFF
--- a/packages/cosmos-oss/cosmos_oss/checkpoints.py
+++ b/packages/cosmos-oss/cosmos_oss/checkpoints.py
@@ -50,7 +50,7 @@ def register_checkpoints():
             ),
             hf=CheckpointFileHf(
                 repository="nvidia/Cosmos-Predict2.5-2B",
-                revision="6787e176dce74a101d922174a95dba29fa5f0c55",
+                revision="f176dc95b4a70f53ce01c4b302851595e7322b00",
                 filename="tokenizer.pth",
             ),
         ),


### PR DESCRIPTION
The pinned revision 6787e176 no longer exists in the `nvidia/Cosmos-Predict2.5-2B` HuggingFace repo (returns 404), likely due to an upstream force-push. Update to the current valid HEAD revision `f176dc95` where `tokenizer.pth` is available.