### PR TITLE
fix: patch CT2.5 inference pipeline for single-frame JPG input

### DIFF
--- a/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
+++ b/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
@@ -268,7 +268,9 @@ class ControlVideo2WorldInference:
         # Frame number settting for chunk-wise long video generation
         num_total_frames = input_frames.shape[1]
         num_frames_per_chunk = num_video_frames_per_chunk - num_conditional_frames
-        if num_video_frames_per_chunk == 1:
+        if num_video_frames_per_chunk == 1 or num_total_frames <= num_video_frames_per_chunk:
+            # Single-chunk path: either explicit 1-frame chunks, or the input is
+            # shorter than one chunk and will be padded up by _pad_input_frames.
             num_chunks = 1
         else:
             num_generated_frames_vid2vid = num_total_frames - num_video_frames_per_chunk
@@ -297,10 +299,16 @@ class ControlVideo2WorldInference:
                 padding = last_frame.repeat(1, num_video_frames_per_chunk - num_total_frames, 1, 1)
                 input_frames = torch.cat([input_frames, padding], dim=1)
             elif padding_mode == "reflect":
-                while input_frames.shape[1] < num_video_frames_per_chunk:
-                    padding = min(input_frames.shape[1] - 1, num_video_frames_per_chunk - input_frames.shape[1])
-                    padding_frames = input_frames.flip(dims=[1])[:, :padding, :, :]
+                if input_frames.shape[1] == 1:
+                    # Reflect padding is undefined for T=1 (nothing to mirror); fall back to repeat.
+                    last_frame = input_frames[:, -1:, :, :]
+                    padding_frames = last_frame.repeat(1, num_video_frames_per_chunk - input_frames.shape[1], 1, 1)
                     input_frames = torch.cat([input_frames, padding_frames], dim=1)
+                else:
+                    while input_frames.shape[1] < num_video_frames_per_chunk:
+                        padding = min(input_frames.shape[1] - 1, num_video_frames_per_chunk - input_frames.shape[1])
+                        padding_frames = input_frames.flip(dims=[1])[:, :padding, :, :]
+                        input_frames = torch.cat([input_frames, padding_frames], dim=1)
             else:
                 raise ValueError(f"Invalid padding mode: {padding_mode}")
         return input_frames


### PR DESCRIPTION
CT2.5 inference pipeline assumes multi-frame video input and breaks in two places when fed a single JPG (T=1), which is exactly our paired image-translation use case. Both fixes land in cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py.

_pad_input_frames hits an infinite loop. Reflect-padding has nothing to mirror off when T=1, so padding stays at 0 and the while-loop never advances. Switched to repeat-padding (same frame duplicated 93x) for the T=1 case. As a side effect this matches our training distribution, where the MP4s are also static 93-frame loops.

_get_num_chunks returns 0 for short inputs, after which torch.cat crashes with "expected a non-empty list of Tensors". The chunk-count arithmetic underflows when input length is shorter than one chunk. Clamped num_chunks to at least 1 when
num_total_frames <= num_video_frames_per_chunk; the padding fix above fills the chunk.

Both only kick in on the T=1 path -- normal multi-frame video inference is unchanged. 