### PR TITLE
Expose CFG-parallel Transfer2.5 inference

### DIFF
--- a/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
+++ b/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py
@@ -103,6 +103,7 @@ class ControlVideo2WorldInference:
         self.s3_credential_path = s3_credential_path
         self.cache_dir = cache_dir
         self.cache_text_encoder = cache_text_encoder
+        self._validate_cfg_parallel(process_group, cfg_parallel)
         if exp_override_opts is None:
             exp_override_opts = []
         # no need to load base model separately at inference
@@ -198,6 +199,23 @@ class ControlVideo2WorldInference:
         self.config = config
         self.batch_size = 1
         self.benchmark_timer = benchmark_timer
+
+    @staticmethod
+    def _validate_cfg_parallel(process_group: Optional[torch.distributed.ProcessGroup], cfg_parallel: bool) -> None:
+        if not cfg_parallel:
+            return
+        if process_group is None:
+            raise ValueError(
+                "cfg_parallel requires context parallelism. Run with torchrun and context_parallel_size > 1."
+            )
+
+        cp_size = process_group.size()
+        if cp_size <= 1 or cp_size % 2 != 0:
+            raise ValueError("cfg_parallel requires an even context-parallel group size greater than 1.")
+
+        world_size = distributed.get_world_size()
+        if world_size > 1 and cp_size != world_size:
+            raise ValueError("cfg_parallel currently requires the context-parallel group to span WORLD_SIZE.")
 
     def _get_data_batch_input(
         self,

--- a/cosmos_transfer2/config.py
+++ b/cosmos_transfer2/config.py
@@ -303,6 +303,24 @@ class SetupArguments(CommonSetupArguments):
     # Override defaults
     # pyrefly: ignore  # invalid-annotation
     model: get_model_literal(BASE_MODEL_VARIANTS) = DEFAULT_MODEL_KEY.name
+    cfg_parallel: bool = False
+    """Parallelize classifier-free guidance across two context-parallel rank groups. Requires an even context_parallel_size greater than 1."""
+
+    @pydantic.model_validator(mode="after")
+    def validate_cfg_parallel(self) -> Self:
+        if not self.cfg_parallel:
+            return self
+
+        if self.context_parallel_size is None:
+            raise ValueError("cfg_parallel requires context_parallel_size to be set.")
+        if self.context_parallel_size <= 1 or self.context_parallel_size % 2 != 0:
+            raise ValueError("cfg_parallel requires an even context_parallel_size greater than 1.")
+
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        if self.context_parallel_size != world_size:
+            raise ValueError("cfg_parallel requires context_parallel_size to match WORLD_SIZE.")
+
+        return self
 
 
 Guidance = Annotated[int, pydantic.Field(ge=0, le=7)]

--- a/cosmos_transfer2/inference.py
+++ b/cosmos_transfer2/inference.py
@@ -131,6 +131,7 @@ class Control2WorldInference:
             use_cp_wan=args.enable_parallel_tokenizer,
             wan_cp_grid=args.parallel_tokenizer_grid,
             benchmark_timer=self.benchmark_timer if args.benchmark else None,
+            cfg_parallel=args.cfg_parallel,
             config_file=args.config_file,
         )
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -58,6 +58,16 @@ For multi-GPU inference on a single control or to run multiple control variants,
 torchrun --nproc_per_node=8 --master_port=12341 examples/inference.py -i assets/robot_example/depth/robot_depth_spec.json -o outputs/depth
 ```
 
+For classifier-free guidance, the base Transfer2.5 model normally evaluates the conditional and unconditional branches sequentially. To run those branches in parallel, use an even number of GPUs and enable CFG parallelism:
+```bash
+torchrun --nproc_per_node=8 --master_port=12341 examples/inference.py \
+    -i assets/robot_example/edge/robot_edge_spec.json \
+    -o outputs/edge_cfg_parallel \
+    --cfg_parallel \
+    --benchmark
+```
+`--cfg_parallel` requires `context_parallel_size` to match the torchrun world size and to be greater than 1. The `--benchmark` option reports `generate_img2world` timing for before/after comparisons.
+
 We provide example parameter files for each individual control variant along with a multi-control variant:
 
 | Variant | Parameter File  |

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from cosmos_transfer2.config import DEFAULT_MODEL_KEY, SetupArguments
+from cosmos_transfer2.multiview_config import MultiviewSetupArguments
+from cosmos_transfer2.robot_multiview_control_agibot_config import RobotMultiviewControlAgibotSetupArguments
+
+
+def test_cfg_parallel_is_base_setup_only():
+    assert "cfg_parallel" in SetupArguments.model_fields
+    assert "cfg_parallel" not in MultiviewSetupArguments.model_fields
+    assert "cfg_parallel" not in RobotMultiviewControlAgibotSetupArguments.model_fields
+
+
+def test_cfg_parallel_requires_full_even_context_parallel_world(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    args = SetupArguments(
+        output_dir=tmp_path,
+        model=DEFAULT_MODEL_KEY.name,
+        cfg_parallel=True,
+        context_parallel_size=4,
+    )
+
+    assert args.cfg_parallel
+
+    with pytest.raises(ValidationError, match="even context_parallel_size"):
+        SetupArguments(
+            output_dir=tmp_path,
+            model=DEFAULT_MODEL_KEY.name,
+            cfg_parallel=True,
+            context_parallel_size=3,
+        )
+
+    with pytest.raises(ValidationError, match="match WORLD_SIZE"):
+        SetupArguments(
+            output_dir=tmp_path,
+            model=DEFAULT_MODEL_KEY.name,
+            cfg_parallel=True,
+            context_parallel_size=2,
+        )


### PR DESCRIPTION
## Summary
- Exposes the existing CFG-parallel Transfer2.5 inference path through the base inference setup arguments.
- Validates that CFG parallelism uses an even context-parallel world matching `WORLD_SIZE` before model loading.
- Documents the benchmark command and adds focused config tests for the base-only CLI surface.

Addresses #195.

## Validation
- `PYENV_VERSION=3.12.9 PYTHONPATH=packages/cosmos-cuda:packages/cosmos-oss python -m pytest -q --noconftest -o addopts="" tests/config_test.py`
- `PYENV_VERSION=3.12.9 python -m ruff format --check cosmos_transfer2/config.py cosmos_transfer2/inference.py cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py tests/config_test.py`
- `PYENV_VERSION=3.12.9 python -m ruff check cosmos_transfer2/config.py cosmos_transfer2/inference.py cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py tests/config_test.py`
- `PYENV_VERSION=3.12.9 python -m py_compile cosmos_transfer2/config.py cosmos_transfer2/inference.py cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py tests/config_test.py`
- `git diff --check`
- `uvx pre-commit run --files cosmos_transfer2/config.py cosmos_transfer2/inference.py cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py docs/inference.md tests/config_test.py`

## Notes
- Full multi-GPU inference benchmarking was not run locally because the available environment is missing the CUDA runtime library required by `transformer_engine` (`libcudnn_graph.so.9`).
